### PR TITLE
Tool Models from "item/generated" to "item/handheld"

### DIFF
--- a/src/main/resources/assets/indrev/models/item/copper_axe.json
+++ b/src/main/resources/assets/indrev/models/item/copper_axe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/copper_axe"
   }

--- a/src/main/resources/assets/indrev/models/item/copper_hoe.json
+++ b/src/main/resources/assets/indrev/models/item/copper_hoe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/copper_hoe"
   }

--- a/src/main/resources/assets/indrev/models/item/copper_pickaxe.json
+++ b/src/main/resources/assets/indrev/models/item/copper_pickaxe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/copper_pickaxe"
   }

--- a/src/main/resources/assets/indrev/models/item/copper_shovel.json
+++ b/src/main/resources/assets/indrev/models/item/copper_shovel.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/copper_shovel"
   }

--- a/src/main/resources/assets/indrev/models/item/copper_sword.json
+++ b/src/main/resources/assets/indrev/models/item/copper_sword.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/copper_sword"
   }

--- a/src/main/resources/assets/indrev/models/item/steel_axe.json
+++ b/src/main/resources/assets/indrev/models/item/steel_axe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/steel_axe"
   }

--- a/src/main/resources/assets/indrev/models/item/steel_hoe.json
+++ b/src/main/resources/assets/indrev/models/item/steel_hoe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/steel_hoe"
   }

--- a/src/main/resources/assets/indrev/models/item/steel_pickaxe.json
+++ b/src/main/resources/assets/indrev/models/item/steel_pickaxe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/steel_pickaxe"
   }

--- a/src/main/resources/assets/indrev/models/item/steel_shovel.json
+++ b/src/main/resources/assets/indrev/models/item/steel_shovel.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/steel_shovel"
   }

--- a/src/main/resources/assets/indrev/models/item/steel_sword.json
+++ b/src/main/resources/assets/indrev/models/item/steel_sword.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/steel_sword"
   }

--- a/src/main/resources/assets/indrev/models/item/tin_axe.json
+++ b/src/main/resources/assets/indrev/models/item/tin_axe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/tin_axe"
   }

--- a/src/main/resources/assets/indrev/models/item/tin_hoe.json
+++ b/src/main/resources/assets/indrev/models/item/tin_hoe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/tin_hoe"
   }

--- a/src/main/resources/assets/indrev/models/item/tin_pickaxe.json
+++ b/src/main/resources/assets/indrev/models/item/tin_pickaxe.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/tin_pickaxe"
   }

--- a/src/main/resources/assets/indrev/models/item/tin_shovel.json
+++ b/src/main/resources/assets/indrev/models/item/tin_shovel.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/tin_shovel"
   }

--- a/src/main/resources/assets/indrev/models/item/tin_sword.json
+++ b/src/main/resources/assets/indrev/models/item/tin_sword.json
@@ -1,5 +1,5 @@
 {
-  "parent": "item/generated",
+  "parent": "item/handheld",
   "textures": {
     "layer0": "indrev:item/tin_sword"
   }


### PR DESCRIPTION
the parent of "item/generated" is like holding any item, while "item/handheld" is the model used for tools, and all of the tools, besides the endgame tools, used "item/generated"

This picture is before,
![2021-01-13_12 46 41](https://user-images.githubusercontent.com/52116771/104503810-c4360380-559e-11eb-9691-ddcdf630313b.png)
This one is after the change
![2021-01-13_12 50 32](https://user-images.githubusercontent.com/52116771/104503843-d57f1000-559e-11eb-89f6-b808da161d0d.png)

Here is Vanilla for comparison
![2021-01-13_12 46 53](https://user-images.githubusercontent.com/52116771/104503861-ddd74b00-559e-11eb-9995-c39d996c41f9.png)

