### PR TITLE
Fix wrong sign for degrees

### DIFF
--- a/src/main/kotlin/me/steven/indrev/gui/widgets/machines/WTemperature.kt
+++ b/src/main/kotlin/me/steven/indrev/gui/widgets/machines/WTemperature.kt
@@ -26,7 +26,7 @@ class WTemperature(private val temperatureComponent: TemperatureComponent) : WBa
                 TranslatableText("gui.widget.temperature_info.low").formatted(Formatting.GREEN, Formatting.ITALIC)
         }
         information?.add(TranslatableText("gui.widget.temperature").formatted(Formatting.BLUE))
-        information?.add(LiteralText("$temperature / $maxTemperature ºC"))
+        information?.add(LiteralText("$temperature / $maxTemperature °C"))
         information?.add(info)
     }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7559492/116313092-b12cf500-a783-11eb-91e7-9071f414e92d.png)
After:
![image](https://user-images.githubusercontent.com/7559492/116313120-bb4ef380-a783-11eb-99e3-b35769d86660.png)
