### PR TITLE
[SUGGESTION] Change mod group icon to something more representive of the mod

### DIFF
--- a/src/main/kotlin/me/steven/indrev/IndustrialRevolution.kt
+++ b/src/main/kotlin/me/steven/indrev/IndustrialRevolution.kt
@@ -1,6 +1,7 @@
 package me.steven.indrev
 
 import me.steven.indrev.api.IRServerPlayerEntityExtension
+import me.steven.indrev.api.machines.Tier
 import me.steven.indrev.blockentities.MachineBlockEntity
 import me.steven.indrev.config.IRConfig
 import me.steven.indrev.datagen.DataGeneratorManager
@@ -151,7 +152,7 @@ object IndustrialRevolution : ModInitializer {
     const val MOD_ID = "indrev"
 
     val MOD_GROUP: ItemGroup =
-        FabricItemGroupBuilder.build(identifier("indrev_group")) { ItemStack { IRBlockRegistry.NIKOLITE_ORE().asItem() } }
+        FabricItemGroupBuilder.build(identifier("indrev_group")) { ItemStack { MachineRegistry.PULVERIZER_REGISTRY.block(Tier.MK4).asItem() } }
 
     val COAL_GENERATOR_HANDLER = CoalGeneratorScreenHandler.SCREEN_ID.registerScreenHandler(::CoalGeneratorScreenHandler)
     val SOLAR_GENERATOR_HANDLER = SolarGeneratorScreenHandler.SCREEN_ID.registerScreenHandler(::SolarGeneratorScreenHandler)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19669673/119452494-ba839000-bd36-11eb-9d4d-74dfe8ab2c51.png)
Is it a world gen mod? No. Is it a ore gen mod? No. Is it a tech mod about machines? Yes

This changes the mod group icon to a tier 4 pulverizer instead of nikolite ore