### PR TITLE
Make the farmer work with cocoa beans

### DIFF
--- a/src/main/kotlin/me/steven/indrev/blockentities/farms/ChopperBlockEntity.kt
+++ b/src/main/kotlin/me/steven/indrev/blockentities/farms/ChopperBlockEntity.kt
@@ -169,7 +169,7 @@ class ChopperBlockEntity(tier: Tier) : AOEMachineBlockEntity<BasicMachineConfig>
                 world?.syncWorldEvent(2005, pos, 0)
                 itemStack.decrement(1)
             }
-            block == Blocks.AIR
+            block is AirBlock
                     && item is BlockItem
                     && (item.isIn(ItemTags.SAPLINGS) || item.block is MushroomPlantBlock || item.block is BambooBlock)
                     && item.block.defaultState.canPlaceAt(world, pos)

--- a/src/main/kotlin/me/steven/indrev/blockentities/farms/FarmerBlockEntity.kt
+++ b/src/main/kotlin/me/steven/indrev/blockentities/farms/FarmerBlockEntity.kt
@@ -108,10 +108,9 @@ class FarmerBlockEntity(tier: Tier) : AOEMachineBlockEntity<BasicMachineConfig>(
                         val directions = arrayOf(Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST)
 
                         directions.forEach loop@ {
-                            //print (it as String + "\n")
-                            if (world.getBlockState(pos.offset(it)).block == Blocks.JUNGLE_LOG) {
+                            var supportBlock = world.getBlockState(pos.offset(it)).block
+                            if (supportBlock == Blocks.JUNGLE_LOG || supportBlock == Blocks.JUNGLE_WOOD || supportBlock == Blocks.STRIPPED_JUNGLE_LOG || supportBlock == Blocks.STRIPPED_JUNGLE_WOOD) {
                                 cropState = cropState.with(CocoaBlock.FACING, it)
-                                //print("CHOOSEN\n")
                                 return@loop
                             }
                         }

--- a/src/main/kotlin/me/steven/indrev/blockentities/farms/FarmerBlockEntity.kt
+++ b/src/main/kotlin/me/steven/indrev/blockentities/farms/FarmerBlockEntity.kt
@@ -11,15 +11,14 @@ import me.steven.indrev.registry.MachineRegistry
 import me.steven.indrev.utils.map
 import me.steven.indrev.utils.toVec3d
 import net.minecraft.block.*
-import net.minecraft.item.BlockItem
-import net.minecraft.item.BoneMealItem
-import net.minecraft.item.Item
-import net.minecraft.item.ItemStack
+import net.minecraft.item.*
 import net.minecraft.loot.context.LootContext
 import net.minecraft.loot.context.LootContextParameters
 import net.minecraft.server.world.ServerWorld
+import net.minecraft.state.property.DirectionProperty
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Box
+import net.minecraft.util.math.Direction
 
 class FarmerBlockEntity(tier: Tier) : AOEMachineBlockEntity<BasicMachineConfig>(tier, MachineRegistry.FARMER_REGISTRY), UpgradeProvider {
 
@@ -79,7 +78,7 @@ class FarmerBlockEntity(tier: Tier) : AOEMachineBlockEntity<BasicMachineConfig>(
         val performedAction = inventory?.inputSlots?.any { slot ->
             val stack = inventory.getStack(slot)
             val item = stack.item
-            val isCropBlock = block is CropBlock || block is StemBlock || block is SweetBerryBushBlock
+            val isCropBlock = block is CropBlock || block is StemBlock || block is SweetBerryBushBlock || block is CocoaBlock
             when {
                 item is BoneMealItem && isCropBlock && (block as Fertilizable).isFertilizable(world, pos, state, false) -> {
                     stack.decrement(1)
@@ -102,8 +101,22 @@ class FarmerBlockEntity(tier: Tier) : AOEMachineBlockEntity<BasicMachineConfig>(
                     droppedStacks.forEach { inventory.output(it) }
                     true
                 }
-                block == Blocks.AIR && canPlant(item) && stack.count > 1 -> {
-                    val cropState = (item as BlockItem).block.defaultState
+                block is AirBlock && canPlant(item) && stack.count > 1 -> {
+                    var cropState = (item as BlockItem).block.defaultState
+
+                    if (item.block is CocoaBlock) {
+                        val directions = arrayOf(Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST)
+
+                        directions.forEach loop@ {
+                            //print (it as String + "\n")
+                            if (world.getBlockState(pos.offset(it)).block == Blocks.JUNGLE_LOG) {
+                                cropState = cropState.with(CocoaBlock.FACING, it)
+                                //print("CHOOSEN\n")
+                                return@loop
+                            }
+                        }
+                    }
+
                     if (cropState.canPlaceAt(world, pos) && world.isAir(pos)) {
                         world.setBlockState(pos, cropState)
                         stack.count--
@@ -124,6 +137,7 @@ class FarmerBlockEntity(tier: Tier) : AOEMachineBlockEntity<BasicMachineConfig>(
                         || item.block is StemBlock
                         || item.block == Blocks.SUGAR_CANE
                         || item.block is SweetBerryBushBlock
+                        || item.block is CocoaBlock
                 )
 
     private fun canHarvest(slot: Int, state: BlockState, block: Block, item: Item): Boolean =
@@ -132,6 +146,7 @@ class FarmerBlockEntity(tier: Tier) : AOEMachineBlockEntity<BasicMachineConfig>(
                 && (item is BlockItem && item.block == block || slot == 4))
                 || block is GourdBlock
                 || block == Blocks.SUGAR_CANE
+                || (block is CocoaBlock && state[CocoaBlock.AGE] == 2)
 
     override fun getWorkingArea(): Box = Box(pos).expand(range.toDouble(), 0.0, range.toDouble())
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19669673/119460633-2ec23180-bd3f-11eb-8aa2-85b42656a1bd.png)
Planting, bonemealing and harvesting all works
Cocoa beans are only placed on jungle logs/jungle wood/stripped jungle log/stripped jungle wood and are always correctly rotated. They can be placed on all four sides of a log.

Also fixes the farmer and chopper not working in cave air (in caves) or void air (in the end)

Fixes #186 