### PR TITLE
Fixes to REI fluid infuser gui

### DIFF
--- a/src/main/kotlin/me/steven/indrev/compat/rei/categories/IRMachineRecipeCategory.kt
+++ b/src/main/kotlin/me/steven/indrev/compat/rei/categories/IRMachineRecipeCategory.kt
@@ -1,5 +1,6 @@
 package me.steven.indrev.compat.rei.categories
 
+import alexiil.mc.lib.attributes.fluid.amount.FluidAmount
 import it.unimi.dsi.fastutil.ints.IntList
 import me.shedaniel.math.Point
 import me.shedaniel.math.Rectangle
@@ -61,12 +62,12 @@ open class IRMachineRecipeCategory(
                 )
         }
         if (recipe is IRFluidRecipe) {
-            if (recipe.fluidInput != null) {
+            if (recipe.fluidInput != null && recipe.fluidInput?.amount() != FluidAmount.ZERO) {
                 val inputFluidPoint = Point(startPoint.x - 20, startPoint.y)
                 createREIFluidWidget(widgets, inputFluidPoint, recipe.fluidInput!!)
             }
-            if (recipe.fluidOutput != null) {
-                val outputFluidPoint = Point(startPoint.x + 80, startPoint.y)
+            if (recipe.fluidOutput != null && recipe.fluidOutput?.amount() != FluidAmount.ZERO) {
+                val outputFluidPoint = Point(startPoint.x + 83, startPoint.y)
                 createREIFluidWidget(widgets, outputFluidPoint, recipe.fluidOutput!!)
             }
         }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/19669673/119618082-c89ee280-be02-11eb-9322-4eaee73d35c0.png)

- Fixes missing texture is there is no resulting liquid (when creating paper for example)
- Fix the output slot and output liquid overlapping