### PR TITLE
Visualize choppers proper range

### DIFF
--- a/src/main/kotlin/me/steven/indrev/blockentities/farms/AOEMachineBlockEntityRenderer.kt
+++ b/src/main/kotlin/me/steven/indrev/blockentities/farms/AOEMachineBlockEntityRenderer.kt
@@ -9,6 +9,7 @@ import net.minecraft.client.render.WorldRenderer
 import net.minecraft.client.render.block.entity.BlockEntityRenderDispatcher
 import net.minecraft.client.render.block.entity.BlockEntityRenderer
 import net.minecraft.client.util.math.MatrixStack
+import net.minecraft.util.math.Box
 
 
 class AOEMachineBlockEntityRenderer(dispatcher: BlockEntityRenderDispatcher) : BlockEntityRenderer<AOEMachineBlockEntity<*>>(dispatcher) {
@@ -23,23 +24,32 @@ class AOEMachineBlockEntityRenderer(dispatcher: BlockEntityRenderDispatcher) : B
         if (blockEntity.renderWorkingArea) {
             val area = blockEntity.getWorkingArea()
 
-            RenderSystem.enableBlend()
-            RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO)
-            RenderSystem.lineWidth((MinecraftClient.getInstance().window.framebufferHeight.toFloat() / 1920.0f * 2.5f).coerceAtLeast(2.5f))
-            RenderSystem.disableTexture()
-            val pos = blockEntity.pos
-            matrices?.run {
-                push()
-                RenderSystem.enableDepthTest()
-                RenderSystem.depthFunc(515)
-                RenderSystem.depthMask(true)
-                val vertex = vertexConsumers?.getBuffer(RenderLayer.getLines())
-                WorldRenderer.drawBox(this, vertex, area.offset(-pos.x.toDouble(), -pos.y.toDouble(), -pos.z.toDouble()), 1f, 0f, 1f, 1f)
-                pop()
+            renderBox(blockEntity, matrices, vertexConsumers, area, 1f, 0f, 1f)
+
+            if (blockEntity is ChopperBlockEntity) {
+                // Render extra box to show breaking range
+                renderBox(blockEntity, matrices, vertexConsumers, area.expand(4.0, 0.0, 4.0), 1f, 0f, 0f)
             }
-            RenderSystem.enableTexture()
-            RenderSystem.disableBlend()
         }
+    }
+
+    fun renderBox (blockEntity: AOEMachineBlockEntity<*>, matrices: MatrixStack?, vertexConsumers: VertexConsumerProvider?, area: Box, red: Float, green: Float, blue: Float) {
+        RenderSystem.enableBlend()
+        RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SrcFactor.ONE, GlStateManager.DstFactor.ZERO)
+        RenderSystem.lineWidth((MinecraftClient.getInstance().window.framebufferHeight.toFloat() / 1920.0f * 2.5f).coerceAtLeast(2.5f))
+        RenderSystem.disableTexture()
+        val pos = blockEntity.pos
+        matrices?.run {
+            push()
+            RenderSystem.enableDepthTest()
+            RenderSystem.depthFunc(515)
+            RenderSystem.depthMask(true)
+            val vertex = vertexConsumers?.getBuffer(RenderLayer.getLines())
+            WorldRenderer.drawBox(this, vertex, area.offset(-pos.x.toDouble(), -pos.y.toDouble(), -pos.z.toDouble()), red, green, blue, 1f)
+            pop()
+        }
+        RenderSystem.enableTexture()
+        RenderSystem.disableBlend()
     }
 
     override fun rendersOutsideBoundingBox(blockEntity: AOEMachineBlockEntity<*>?): Boolean = true


### PR DESCRIPTION
Choppers break block 4 blocks away from their radius, visualizing this avoids confusion.

![image](https://user-images.githubusercontent.com/19669673/119786691-bab79300-bed0-11eb-928f-8cd48e8795fb.png)


Fixes #206 