### PR TITLE
Clamp durability bar

### DIFF
--- a/src/main/kotlin/me/steven/indrev/items/energy/IREnergyItem.kt
+++ b/src/main/kotlin/me/steven/indrev/items/energy/IREnergyItem.kt
@@ -4,11 +4,12 @@ import me.steven.indrev.gui.tooltip.energy.EnergyTooltipDataProvider
 import me.steven.indrev.utils.energyOf
 import net.minecraft.item.ItemStack
 import kotlin.math.roundToInt
+import net.minecraft.util.math.MathHelper.clamp
 
 interface IREnergyItem : EnergyTooltipDataProvider {
     fun getDurabilityBarProgress(stack: ItemStack?): Int {
         val energyIo = energyOf(stack) ?: return 0
-        return (13.0f - (energyIo.energyCapacity - energyIo.energy) * 13.0f / energyIo.energyCapacity).roundToInt()
+        return (13.0f - (energyIo.energyCapacity - energyIo.energy) * 13.0f / energyIo.energyCapacity).roundToInt() / stack.count
     }
 
     fun hasDurabilityBar(stack: ItemStack?): Boolean = (energyOf(stack)?.energy ?: 0.0) > 0


### PR DESCRIPTION
Prevents there from being an absurdly long durability bar as in
![image](https://user-images.githubusercontent.com/57579569/127942367-a5496d96-afc3-4b49-8f37-4e39a8051529.png)
when batteries are stacked.