### PR TITLE
Use LBA's fluid rendering, rather than a custom method.

### DIFF
--- a/src/main/kotlin/me/steven/indrev/blockentities/storage/TankBlockEntityRenderer.kt
+++ b/src/main/kotlin/me/steven/indrev/blockentities/storage/TankBlockEntityRenderer.kt
@@ -42,6 +42,10 @@ class TankBlockEntityRenderer : BlockEntityRenderer<TankBlockEntity> {
             faces.add(FluidRenderFace.createFlatFaceY(0.1, yHeight, 0.1, 0.9, yHeight, 0.9, 1.0, true, false))
         }
 
+        for (face in faces) {
+            face.light = light;
+        }
+
         volume.render(faces, vertexConsumers, matrices);
     }
 }

--- a/src/main/kotlin/me/steven/indrev/blockentities/storage/TankBlockEntityRenderer.kt
+++ b/src/main/kotlin/me/steven/indrev/blockentities/storage/TankBlockEntityRenderer.kt
@@ -42,7 +42,6 @@ class TankBlockEntityRenderer : BlockEntityRenderer<TankBlockEntity> {
             faces.add(FluidRenderFace.createFlatFaceY(0.1, yHeight, 0.1, 0.9, yHeight, 0.9, 1.0, true, false))
         }
 
-        IRFluidVolumeRenderer.render(entity.world!!, entity.pos, volume, faces, FluidVolumeRenderer.VCPS, matrices)
-        FluidVolumeRenderer.VCPS.draw()
+        volume.render(faces, vertexConsumers, matrices);
     }
 }


### PR DESCRIPTION
This *might* fix https://github.com/GabrielOlvH/Industrial-Revolution/issues/276, but I'm not sure - either way you're not meant to use the FluidRender VCPS field and instead pass the VertexConsumer that the BlockEntityRenderer is given.

(If this does fix #276 then it's an LBA bug *somewhere*, since using that is obviously not meant to cause a memory leak...)

*NOTE: I haven't tested this locally or even compiled it - please test this yourself before merging!*