### PR TITLE
Adds interoperability with Inventory Profiles Next.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,7 @@ dependencies {
     modCompileOnly("net.oskarstrom:DashLoader:2.0-dev12")
     dependencies.ext.lib("io.activej:activej-serializer:${project.activej_version}", true)
     modRuntime("org.yaml:snakeyaml:1.27")
+    modCompileOnly("org.anti-ad.mc:inventory-profiles-next:fabric-1.17.1-1.1.0")
 }
 
 processResources {
@@ -186,7 +187,7 @@ jar {
 
     exclude("me/steven/indrev/datagen")
 }
-
+/*
 // configure the maven publication
 publishing {
     publications {
@@ -215,5 +216,5 @@ publishing {
         }
     }
 }
-
+*/
 compileKotlin.kotlinOptions.jvmTarget = "16"

--- a/src/main/kotlin/me/steven/indrev/gui/IRInventoryScreen.kt
+++ b/src/main/kotlin/me/steven/indrev/gui/IRInventoryScreen.kt
@@ -4,6 +4,8 @@ import io.github.cottonmc.cotton.gui.SyncedGuiDescription
 import io.github.cottonmc.cotton.gui.client.CottonInventoryScreen
 import io.github.cottonmc.cotton.gui.impl.client.MouseInputHandler
 import net.minecraft.entity.player.PlayerEntity
+import org.anti_ad.mc.ipn.api.IPNIgnore
 
+@IPNIgnore
 class IRInventoryScreen<T : SyncedGuiDescription>(controller: T, playerEntity: PlayerEntity) : CottonInventoryScreen<T>(controller, playerEntity) {
 }


### PR DESCRIPTION
The added annotation disables Inventory Profiles Next handling for all screens and containers.

Unfortunately this also catches the Cabinet which is real container and I guess some player might want to sort and have fast move items from their inventory into it. 
This is a limitation of my API on which I will be working to fix :smile:   