### PR TITLE
Fix vein compatibility with AE2 certus quartz

### DIFF
--- a/src/main/resources/data/indrev/veintypes/certus_quartz.json
+++ b/src/main/resources/data/indrev/veintypes/certus_quartz.json
@@ -6,14 +6,9 @@
       "optional": true,
       "output": [
         {
-          "id": "appliedenergistics2:quartz_ore",
+          "id": "ae2:quartz_ore",
           "weight": 8,
           "infiniteWeight": 8
-        },
-        {
-          "id": "appliedenergistics2:charged_quartz_ore",
-          "weight": 3,
-          "infiniteWeight": 3
         },
         {
           "id": "minecraft:stone",


### PR DESCRIPTION
Two small changes to allow the miner to obtain certus quartz for AE2 in Minecraft 1.18:

- The AE2 namespace was changed from "appliedenergistics2:" to "ae2:" in version 10.
- Deleted charged certus quartz ore as it was removed from AE2 in version 10.