### PR TITLE
Fix clearing of different directions.

### DIFF
--- a/src/main/kotlin/me/steven/indrev/blocks/machine/MachineBlock.kt
+++ b/src/main/kotlin/me/steven/indrev/blocks/machine/MachineBlock.kt
@@ -207,6 +207,8 @@ open class MachineBlock(
         notify: Boolean
     ) {
         val blockEntity = world?.getBlockEntity(pos) as? MachineBlockEntity<*> ?: return
+
+        blockEntity.validConnections.clear()
         blockEntity.validConnections.addAll(Direction.values())
     }
 


### PR DESCRIPTION
When placing different (creative) energy containers it can become possible that directions will become added multiple times (EAST x2 etc).
This small PR will delete/remove the directions that are not yet checked.

The issue can be reproduced by placing 2 or more lazuli flux containers, which can become an issue with large counts of valid connections:

https://github.com/GabrielOlvH/Industrial-Revolution/blob/master/src/main/kotlin/me/steven/indrev/utils/machineinteractions.kt#L125

