### PR TITLE
use EnumSet in MachineBlockEntity for valid connection directions

### DIFF
--- a/src/main/kotlin/me/steven/indrev/blockentities/MachineBlockEntity.kt
+++ b/src/main/kotlin/me/steven/indrev/blockentities/MachineBlockEntity.kt
@@ -25,12 +25,13 @@ import net.minecraft.nbt.NbtCompound
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
 import net.minecraft.world.WorldAccess
+import java.util.EnumSet
 import kotlin.collections.set
 
 abstract class MachineBlockEntity<T : IConfig>(val tier: Tier, val registry: MachineRegistry, pos: BlockPos, state: BlockState)
     : BaseMachineBlockEntity(registry.blockEntityType(tier), pos, state) {
 
-    val validConnections = Direction.values().toMutableList()
+    val validConnections: EnumSet<Direction> = EnumSet.allOf(Direction::class.java)
 
     override var guiSyncableComponent: GuiSyncableComponent? = GuiSyncableComponent()
 


### PR DESCRIPTION
Currently, `MachineBlockEntity#validConnections` uses an `ArrayList` for storing connection directions, this is significantly slower than using `EnumSet`, for `contains` operations. this performance difference manifests when large networks transfer energy. No accesses of this value rely on order of elements, so changing the collection implementation used produces no differences in behavior.