### PR TITLE
Tag Search uses $ Tooltips uses #

### DIFF
--- a/src/main/resources/data/indrev/patchouli_books/indrev/en_us/entries/machines/miner.json
+++ b/src/main/resources/data/indrev/patchouli_books/indrev/en_us/entries/machines/miner.json
@@ -32,7 +32,7 @@
     },
     {
       "type": "text",
-      "text": "When looking inside a Data Card Encoder, the ores and modifiers it can encode will be highlighted in your inventory.$(br2)When encoding, some attributes will change in your card, like richness or size.$(br2)$(br)Tip: search \"#indrev:mining_rig_allowed\" on REI to see all allowed ores!"
+      "text": "When looking inside a Data Card Encoder, the ores and modifiers it can encode will be highlighted in your inventory.$(br2)When encoding, some attributes will change in your card, like richness or size.$(br2)$(br)Tip: search \"$indrev:mining_rig_allowed\" on REI to see all allowed ores!"
     },
     {
       "type": "text",


### PR DESCRIPTION
Also this appears to only work for user defined ores in 1.19 as base ores are not found with #indrev:mining_rig_allowed or $indrev:mining_rig_allowed