### PR TITLE
Fix loader 0.15.x compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,14 +195,16 @@ publishing {
 
     // select the repositories you want to publish to
     repositories {
-        maven {
-            url "https://maven.cafeteria.dev/releases"
-            credentials {
-                username = project.property("mcdUsername")
-                password = project.property("mcdPassword")
-            }
-            authentication {
-                basic(BasicAuthentication)
+        if (project.hasProperty("mcdUsername") && project.hasProperty("mcdPassword")) {
+            maven {
+                url "https://maven.cafeteria.dev/releases"
+                credentials {
+                    username = project.property("mcdUsername")
+                    password = project.property("mcdPassword")
+                }
+                authentication {
+                    basic(BasicAuthentication)
+                }
             }
         }
     }

--- a/src/main/kotlin/me/steven/indrev/registry/MachineRegistry.kt
+++ b/src/main/kotlin/me/steven/indrev/registry/MachineRegistry.kt
@@ -55,7 +55,6 @@ class MachineRegistry(private val key: String, val upgradeable: Boolean = true, 
     private val blocks: MutableMap<Tier, Block> = EnumMap(Tier::class.java)
     val blockEntities: MutableMap<Tier, BlockEntityType<*>> = EnumMap(Tier::class.java)
 
-    @Environment(EnvType.CLIENT)
     val modelProvider: MutableMap<Tier, (String) -> UnbakedModel?> = EnumMap(Tier::class.java)
 
     fun blockProvider(blockProvider: MachineRegistry.(Tier) -> Block): MachineRegistry {
@@ -504,7 +503,7 @@ class MachineRegistry(private val key: String, val upgradeable: Boolean = true, 
             .defaultEnergyProvider()
             .defaultFluidStorageProvider()
             .defaultModelProvider()
-        
+
         val ELECTROLYTIC_SEPARATOR_REGISTRY = MachineRegistry("electrolytic_separator", true)
             .blockProvider { tier ->
                 ElectrolyticSeparatorBlock(this, SETTINGS(), tier)


### PR DESCRIPTION
Fabric Loader 0.15.x enforces `@Environment` annotations by removing annotated fields, classes, methods etc. on class load.
This PR backports commit 2a8f79be91ced9db700342574d08de36a781cd0d
I've also taken the liberty of fixing the build.gradle to only add the publish repo if the necessary credentials are set, because the build fails otherwise.

Fixes #565